### PR TITLE
Update to mcc.xsd

### DIFF
--- a/19110/fcc/1.0/fcc.xsd
+++ b/19110/fcc/1.0/fcc.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:fcc="http://standards.iso.org/iso/19110/fcc/1.0" elementFormDefault="qualified" targetNamespace="http://standards.iso.org/iso/19110/fcc/1.0" version="1.0">
   <include schemaLocation="abstract.xsd"/>
-  <!--XML Schema document created by ShapeChange - http://shapechange.net/-->
+  <import namespace="http://standards.iso.org/iso/19110/gfc/1.1" schemaLocation="http://standards.iso.org/iso/19110/gfc/1.1/gfc.xsd"/>
+<!--XML Schema document created by ShapeChange - http://shapechange.net/-->
 </schema>


### PR DESCRIPTION
Add import statement of gfc.xsd (ISO 19110:2016) to allow inclusion of full General Feature Model when describing structured materials. 
The change will not generate errors for those already using fcc.xsd, but will extend the functionality.