### PR TITLE
Update to mir code lists.xml (remove trailing space from "intelligenc…

### DIFF
--- a/19115/-3/mri/1.0/codelists.xml
+++ b/19115/-3/mri/1.0/codelists.xml
@@ -752,12 +752,12 @@
             </cat:CT_CodelistValue>
          </cat:codeEntry>
          <cat:codeEntry>
-            <cat:CT_CodelistValue id="MD_TopicCategoryCode_boundaries ">
+            <cat:CT_CodelistValue id="MD_TopicCategoryCode_boundaries">
                <cat:identifier>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">boundaries </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">boundaries</gco:ScopedName>
                </cat:identifier>
                <cat:name>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">boundaries </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">boundaries</gco:ScopedName>
                </cat:name>
                <cat:definition>
                   <gco:CharacterString>legal land descriptions, maritime boundaries. Examples: political and administrative boundaries, territorial seas, EEZ, port security zones</gco:CharacterString>
@@ -880,12 +880,12 @@
             </cat:CT_CodelistValue>
          </cat:codeEntry>
          <cat:codeEntry>
-            <cat:CT_CodelistValue id="MD_TopicCategoryCode_intelligenceMilitary ">
+            <cat:CT_CodelistValue id="MD_TopicCategoryCode_intelligenceMilitary">
                <cat:identifier>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">intelligenceMilitary </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">intelligenceMilitary</gco:ScopedName>
                </cat:identifier>
                <cat:name>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">intelligenceMilitary </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mri/1.0">intelligenceMilitary</gco:ScopedName>
                </cat:name>
                <cat:definition>
                   <gco:CharacterString>military bases, structures, activities. Examples: barracks, training grounds, military transportation, information collection</gco:CharacterString>


### PR DESCRIPTION
Complaint received that code list entries in mir:codelists.xml "intelligenceMilitary" and "boundaries" both had trailing space in code value (gco:ScopeName) and Code list name (cat:CT_CodeListValue)
Spaces have been removed - no other changes made.