### PR TITLE
Update mcc codelists.xml (remove trailing spaces)

### DIFF
--- a/19115/-3/mcc/1.0/codelists.xml
+++ b/19115/-3/mcc/1.0/codelists.xml
@@ -684,12 +684,12 @@
             </cat:CT_CodelistValue>
          </cat:codeEntry>
          <cat:codeEntry>
-            <cat:CT_CodelistValue id="MD_ScopeCode_aggregate ">
+            <cat:CT_CodelistValue id="MD_ScopeCode_aggregate">
                <cat:identifier>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mcc/1.0">aggregate </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mcc/1.0">aggregate</gco:ScopedName>
                </cat:identifier>
                <cat:name>
-                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mcc/1.0">aggregate </gco:ScopedName>
+                  <gco:ScopedName codeSpace="http://schemas.isotc211.org/19115/-3/mcc/1.0">aggregate</gco:ScopedName>
                </cat:name>
                <cat:definition>
                   <gco:CharacterString>information applies to an aggregate resource</gco:CharacterString>


### PR DESCRIPTION
Complaint received that code list entries in mcc:codelists.xml "aggregate" both had trailing space in code value (gco:ScopeName) and Code list name (cat:CT_CodeListValue)
Spaces have been removed - no other changes made.