### PR TITLE
Update 19115-2 schemaLocation to point to reinserted 19139

### DIFF
--- a/19115/-2/gmi/1.0/acquisitionInformation.xsd
+++ b/19115/-2/gmi/1.0/acquisitionInformation.xsd
@@ -7,9 +7,9 @@ xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/
 		<xs:documentation>This file was created by Ted Habermann during May 2015 to correct omissions (gmx, MI_EnvironmentalRecord) in existing gmi schema ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gss/gss.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="https://schemas.isotc211.org/19139/-/gss/1.0/gss.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
 	<!-- ================================== Classes ================================= -->

--- a/19115/-2/gmi/1.0/contentInformation.xsd
+++ b/19115/-2/gmi/1.0/contentInformation.xsd
@@ -7,8 +7,8 @@ xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/
 		<xs:documentation>This file was created by Ted Habermann during May 2015 to correct omissions (gmx, MI_EnvironmentalRecord) in existing gmi schema ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
 	<!-- ================================== Classes ================================= -->

--- a/19115/-2/gmi/1.0/dataQualityInformation.xsd
+++ b/19115/-2/gmi/1.0/dataQualityInformation.xsd
@@ -8,10 +8,10 @@ xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/
 		<xs:documentation>This file was generated from ISO TC/211 UML class diagrams == 04-04-2008 17:12:48 ====== Name: Lineage - Position: 2</xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gss/gss.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmx/gmx.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="https://schemas.isotc211.org/19139/-/gss/1.0/gss.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="https://schemas.isotc211.org/19139/-/gmx/1.0/gmx.xsd"/>
 	<xs:include schemaLocation="acquisitionInformation.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->

--- a/19115/-2/gmi/1.0/gmi.xsd
+++ b/19115/-2/gmi/1.0/gmi.xsd
@@ -5,10 +5,10 @@
 		<xs:documentation>This file was created by Ted Habermann during May 2015 to correct omissions (gmx, MI_EnvironmentalRecord) in existing gmi schema ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gss/gss.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmx/gmx.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gss" schemaLocation="https://schemas.isotc211.org/19139/-/gss/1.0/gss.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="https://schemas.isotc211.org/19139/-/gmx/1.0/gmx.xsd"/>
 	<xs:include schemaLocation="metadataEntitySet.xsd"/>
 	<xs:include schemaLocation="contentInformation.xsd"/>
 	<xs:include schemaLocation="dataQualityInformation.xsd"/>

--- a/19115/-2/gmi/1.0/metadataEntitySet.xsd
+++ b/19115/-2/gmi/1.0/metadataEntitySet.xsd
@@ -6,8 +6,8 @@ xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/
 		<xs:documentation>This file was created by Ted Habermann during May 2015 to correct omissions (gmx, MI_EnvironmentalRecord) in existing gmi schema ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>	
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>	
 	<xs:include schemaLocation="acquisitionInformation.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->

--- a/19115/-2/gmi/1.0/spatialRepresentationInformation.xsd
+++ b/19115/-2/gmi/1.0/spatialRepresentationInformation.xsd
@@ -5,8 +5,8 @@
 		<xs:documentation>This file was created by Ted Habermann during May 2015 to correct omissions (gmx, MI_EnvironmentalRecord) in existing gmi schema ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/gmd.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>	
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd"/>	
 	<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://www.opengis.net/gml/3.2"/>
 	<xs:include schemaLocation="acquisitionInformation.xsd"/>
 	<!-- ########################################################################### -->

--- a/19115/resources/transforms/ISO19139/toISO19139.xsl
+++ b/19115/resources/transforms/ISO19139/toISO19139.xsl
@@ -158,7 +158,7 @@
     <xsl:if test="name(preceding-sibling::node()[1]) != name()">
       <gmd:hierarchyLevel>
         <gmd:MD_ScopeCode
-            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
+            codeList="https://schemas.isotc211.org/19139/-/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"
             codeListValue="{mdb:MD_MetadataScope/mdb:resourceScope/mcc:MD_ScopeCode}"/>
       </gmd:hierarchyLevel>
       <xsl:if test="mdb:MD_MetadataScope/mdb:name">


### PR DESCRIPTION
In response to https://github.com/ISO-TC211/schemas/issues/24#issuecomment-604402429

This commit updates the `schemaLocation` of http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas used in 19115-2 schemas to point to the new 19139 location.