### PR TITLE
fix: remove trailing space in IE_Imagery.xsd schemaLocation

### DIFF
--- a/19163/-1/igd/1.1.0/igd.xsd
+++ b/19163/-1/igd/1.1.0/igd.xsd
@@ -10,5 +10,5 @@
     </annotation>
     <include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_ImageryAndGriddedData.xsd"/>
     <include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_ThematicGriddedData.xsd"/>
-    <include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_Imagery.xsd "/>
+    <include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_Imagery.xsd"/>
 </schema>


### PR DESCRIPTION
## Problem

Line 13 of `19163/-1/igd/1.1.0/igd.xsd` has a trailing space inside the `schemaLocation` attribute value:

```xml
<include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_Imagery.xsd "/>
```

This causes schema resolution failures when building LXR packages for schemas that include `igd.xsd` (notably `19130-3-smi-1.1.0`).

## Fix

Remove the trailing space:

```xml
<include schemaLocation="../../../../19163/-1/igd/1.1.0/IE_Imagery.xsd"/>
```

Fixes ISO-TC211/schemas-isotc211.github.io#48