### PR TITLE
fix: map gmd:updateScopeDescription to mmi:maintenanceScope in fromISO19139 transform

### DIFF
--- a/19115/resources/transforms/ISO19139/mapping/core.xsl
+++ b/19115/resources/transforms/ISO19139/mapping/core.xsl
@@ -183,6 +183,16 @@
   </xsl:template>
 
 
+  <xsl:template match="gmd:updateScopeDescription" priority="5" mode="from19139to19115-3">
+    <mmi:maintenanceScope>
+      <mcc:MD_Scope>
+        <mcc:levelDescription>
+          <xsl:apply-templates select="gmd:MD_ScopeDescription/*" mode="from19139to19115-3"/>
+        </mcc:levelDescription>
+      </mcc:MD_Scope>
+    </mmi:maintenanceScope>
+  </xsl:template>
+
   <xsl:template match="gmd:hierarchyLevel" priority="5" mode="from19139to19115-3">
     <!-- ************************************************************************ -->
     <!-- gmd:hierarchyLevel and gmd:hierarchyLevelName are combined into a


### PR DESCRIPTION
## Problem

The element `gmd:updateScopeDescription` had no explicit template in the `fromISO19139` XSLT transform. It fell through to the default catch-all template, which simply renamed it to `mmi:updateScopeDescription` by swapping the namespace prefix. This produced invalid output because `mmi:updateScopeDescription` does **not exist** in the ISO 19115-3 schema.

### Before fix

Input (ISO 19139):
```xml
<gmd:updateScopeDescription>
  <gmd:MD_ScopeDescription>
    <gmd:dataset><gco:CharacterString>Test Dataset Scope</gco:CharacterString></gmd:dataset>
  </gmd:MD_ScopeDescription>
</gmd:updateScopeDescription>
```

Output (invalid — `mmi:updateScopeDescription` does not exist in 19115-3):
```xml
<mmi:updateScopeDescription>
  <mcc:MD_ScopeDescription>
    <mcc:dataset><gco:CharacterString>Test Dataset Scope</gco:CharacterString></mcc:dataset>
  </mcc:MD_ScopeDescription>
</mmi:updateScopeDescription>
```

## Fix

Add an explicit template matching `gmd:updateScopeDescription` that maps it to `mmi:maintenanceScope/mcc:MD_Scope/mcc:levelDescription`, which is the correct 19115-3 structure:

```xml
<xsl:template match="gmd:updateScopeDescription" priority="5" mode="from19139to19115-3">
  <mmi:maintenanceScope>
    <mcc:MD_Scope>
      <mcc:levelDescription>
        <xsl:apply-templates select="gmd:MD_ScopeDescription/*" mode="from19139to19115-3"/>
      </mcc:levelDescription>
    </mcc:MD_Scope>
  </mmi:maintenanceScope>
</xsl:template>
```

### After fix

Output (valid 19115-3 structure):
```xml
<mmi:maintenanceScope>
  <mcc:MD_Scope>
    <mcc:levelDescription>
      <mcc:dataset><gco:CharacterString>Test Dataset Scope</gco:CharacterString></mcc:dataset>
    </mcc:levelDescription>
  </mcc:MD_Scope>
</mmi:maintenanceScope>
```

## Verification

Tested with three scenarios using Saxon HE 9.7:

| Test case | Result |
|-----------|--------|
| `updateScope` + `updateScopeDescription` together | `updateScopeDescription` correctly mapped to `mmi:maintenanceScope/mcc:levelDescription` |
| `updateScopeDescription` alone (with `<gmd:other>` child) | Correctly mapped with `mcc:other` content preserved |
| `updateScope` only, no `updateScopeDescription` | No regression — existing mapping unchanged |

Fixes #5